### PR TITLE
ENH: Upgrade visualizer rendering to use q2templates

### DIFF
--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -26,9 +26,12 @@ def plot(output_dir: str, metadata: qiime.Metadata,
     if custom_axis is not None:
         # put custom_axis inside a list to workaround the type system not
         # supporting lists of types
-        html = viz.make_emperor(standalone=False, custom_axes=[custom_axis])
+        html = viz.make_emperor(standalone=True, custom_axes=[custom_axis])
     else:
-        html = viz.make_emperor(standalone=False)
+        html = viz.make_emperor(standalone=True)
     viz.copy_support_files(output_dir)
+    with open(os.path.join(output_dir, 'emperor.html'), 'w') as fh:
+        fh.write(html)
+
     index = os.path.join(TEMPLATES, 'index.html')
-    q2templates.render(index, output_dir, context={'emperor': html})
+    q2templates.render(index, output_dir)

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -1,0 +1,34 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, Emperor development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os
+import pkg_resources
+
+import qiime
+import skbio
+import q2templates
+from emperor import Emperor
+
+TEMPLATES = pkg_resources.resource_filename('q2_emperor', 'assets')
+
+
+def plot(output_dir: str, metadata: qiime.Metadata,
+         pcoa: skbio.OrdinationResults, custom_axis: str=None) -> None:
+
+    mf = metadata.to_dataframe()
+    viz = Emperor(pcoa, mf, remote='.')
+
+    if custom_axis is not None:
+        # put custom_axis inside a list to workaround the type system not
+        # supporting lists of types
+        html = viz.make_emperor(standalone=False, custom_axes=[custom_axis])
+    else:
+        html = viz.make_emperor(standalone=False)
+    viz.copy_support_files(output_dir)
+    index = os.path.join(TEMPLATES, 'index.html')
+    q2templates.render(index, output_dir, context={'emperor': html})

--- a/q2_emperor/assets/index.html
+++ b/q2_emperor/assets/index.html
@@ -1,34 +1,20 @@
 {% extends 'base.html' %}
 
-{% block head%}
+{% block head %}
 
-  <script src="./vendor/js/require-2.1.22.min.js"></script>
-  <script src="./vendor/js/jquery-2.1.4.min.js"></script>
-  <meta charset="utf-8">
-
-  <style>
-    html, body {
-        height: 100vh;
-        width: 100vw;
+<style media="screen">
+    iframe {
+        height: calc(100vh - 85px);
+        width: 100%;
+        border: none;
     }
-
-    canvas, .emperor-plot-wrapper {
-        width: 100vw;
-        height: calc(100vh - 85px) !important;
-    }
-
-    div[name="emperor-tabs-container"],
-    .emperor-plot-menu {
-        height: calc(100vh - 85px) !important;
-    }
-
-    .slick-viewport {
-        height: 100% !important;
-    }
-  </style>
+</style>
 
 {% endblock %}
 
 {% block content %}
-    {{ emperor }}
+    <div class="row text-center">
+        <iframe src="./emperor.html"></iframe>
+    </div>
+
 {% endblock %}

--- a/q2_emperor/assets/index.html
+++ b/q2_emperor/assets/index.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+
+{% block head%}
+
+  <script src="./vendor/js/require-2.1.22.min.js"></script>
+  <script src="./vendor/js/jquery-2.1.4.min.js"></script>
+  <meta charset="utf-8">
+
+  <style>
+    html, body {
+        height: 100vh;
+        width: 100vw;
+    }
+
+    canvas, .emperor-plot-wrapper {
+        width: 100vw;
+        height: calc(100vh - 85px) !important;
+    }
+
+    div[name="emperor-tabs-container"],
+    .emperor-plot-menu {
+        height: calc(100vh - 85px) !important;
+    }
+
+    .slick-viewport {
+        height: 100% !important;
+    }
+  </style>
+
+{% endblock %}
+
+{% block content %}
+    {{ emperor }}
+{% endblock %}

--- a/q2_emperor/plugin_setup.py
+++ b/q2_emperor/plugin_setup.py
@@ -6,36 +6,12 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime
-import skbio
-
-from qiime.plugin import Plugin, Metadata, Str
 
 import q2_emperor
+from ._plot import plot
+
+from qiime.plugin import Plugin, Metadata, Str
 from q2_types import PCoAResults
-from emperor import Emperor
-from os.path import join
-
-
-def plot(output_dir: str, metadata: qiime.Metadata,
-         pcoa: skbio.OrdinationResults, custom_axis: str=None) -> None:
-
-    mf = metadata.to_dataframe()
-
-    output = join(output_dir, 'emperor-required-resources/')
-    viz = Emperor(pcoa, mf, remote='.')
-
-    with open(join(output_dir, 'index.html'), 'w') as f:
-        if custom_axis is not None:
-            # put custom_axis inside a list to workaround the type system not
-            # supporting lists of types
-            html = viz.make_emperor(standalone=True, custom_axes=[custom_axis])
-        else:
-            html = viz.make_emperor(standalone=True)
-        viz.copy_support_files(output_dir)
-        f.write(html)
-
-    return None
 
 
 plugin = Plugin(

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     version='0.0.5',
     packages=find_packages(),
     install_requires=['qiime >= 2.0.5', 'q2-types >= 0.0.5', 'emperor',
-                      'scikit-bio'],
+                      'scikit-bio', 'q2templates'],
     author="Yoshiki Vazquez-Baeza",
     author_email="yoshiki@ucsd.edu",
     description="Display ordination plots",
@@ -23,5 +23,6 @@ setup(
     entry_points={
         'qiime.plugins':
         ['q2-emperor=q2_emperor.plugin_setup:plugin']
-    }
+    },
+    package_data={'q2_emperor': ['assets/index.html']}
 )


### PR DESCRIPTION
Upgrades visualization to use the new `q2templates` package. This allows for rendering visualizations in a consistent layout that would only require changes to `q2templates` to modify. 

Specific changes to this repo include the moving of `plot` to it's own file (just for consistency with other plugins), and the addition of the html template assets to be rendered against `q2templates`. The Emperor plot is changed to be non-standalone and is injected into the template (which includes the two assets required by a non-standalone plot), and also involves a few CSS tweaks in the `assets/index.html` to kind of make it look pretty within the template.