### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n test-env python=$PYTHON_VERSION nose flake8 numpy emperor -c conda-forge
+  - conda create --yes -n test-env python=$PYTHON_VERSION nose numpy emperor -c conda-forge
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip https://github.com/qiime2/q2-types/archive/master.zip https://github.com/qiime2/q2templates/archive/master.zip
+  - pip install flake8
   - pip install .
+  - git clone https://github.com/qiime2/q2lint
 script:
   - nosetests
-  - flake8 q2_emperor setup.py
+  - flake8
+  - python q2lint/q2lint.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, QIIME 2 Development Team
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,11 +13,11 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of q2-emperor nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE

--- a/q2_emperor/__init__.py
+++ b/q2_emperor/__init__.py
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Emperor development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-__version__ = '0.0.7.dev0'
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution('q2-emperor').version

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Emperor development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,7 +9,7 @@
 import os
 import pkg_resources
 
-import qiime
+import qiime2
 import skbio
 import q2templates
 from emperor import Emperor
@@ -18,7 +18,7 @@ TEMPLATES = pkg_resources.resource_filename('q2_emperor', 'assets')
 
 
 def plot(output_dir: str, pcoa: skbio.OrdinationResults,
-         metadata: qiime.Metadata, custom_axis: str=None) -> None:
+         metadata: qiime2.Metadata, custom_axis: str=None) -> None:
 
     mf = metadata.to_dataframe()
     viz = Emperor(pcoa, mf, remote='.')

--- a/q2_emperor/plugin_setup.py
+++ b/q2_emperor/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Emperor development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,8 +10,8 @@
 import q2_emperor
 from ._plot import plot
 
-from qiime.plugin import Plugin, Metadata, Str
-from q2_types import PCoAResults
+from qiime2.plugin import Plugin, Metadata, Str
+from q2_types.ordination import PCoAResults
 
 
 plugin = Plugin(

--- a/q2_emperor/tests/__init__.py
+++ b/q2_emperor/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Emperor development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Emperor development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,18 +10,17 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-emperor",
-    # todo stop duplicating version string
-    version='0.0.7.dev0',
+    version='2017.2.0.dev0',
     packages=find_packages(),
-    install_requires=['qiime >= 2.0.6', 'q2-types >= 0.0.6', 'emperor',
-                      'scikit-bio', 'q2templates >= 0.0.6'],
+    install_requires=['qiime2 == 2017.2.*', 'q2-types == 2017.2.*',
+                      'q2templates == 2017.2.*', 'emperor', 'scikit-bio'],
     author="Yoshiki Vazquez-Baeza",
     author_email="yoshiki@ucsd.edu",
     description="Display ordination plots",
     license='BSD-3-Clause',
-    url="http://emperor.microbio.me",
+    url="https://qiime2.org",
     entry_points={
-        'qiime.plugins':
+        'qiime2.plugins':
         ['q2-emperor=q2_emperor.plugin_setup:plugin']
     },
     package_data={'q2_emperor': ['assets/index.html']}


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.