### PR TITLE
MAINT: remove changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Version 0.0.2 (2016-08-09)
-
-* Added citation and user support information to plugin.
-
-# Version 0.0.1 (2016-07-14)
-
-Initial alpha release. At this stage, major backwards-incompatible API changes are expected to happen.


### PR DESCRIPTION
We're currently removing all change logs as these haven't been useful or well-maintained yet. We're working on a new solution for presenting this information which will be in place by the time we transition to our beta release. In the meantime, we'll present the most important changes in our release notes, and are available to help users and developers transition between releases on Slack, the QIIME 2 Forum, or repository issue trackers.