### PR TITLE
BUG: remove white 'footer' from viz

### DIFF
--- a/q2_emperor/assets/index.html
+++ b/q2_emperor/assets/index.html
@@ -3,10 +3,18 @@
 {% block head %}
 
 <style media="screen">
+    body {
+        overflow: hidden; /* hide rounding error in viewport calc */
+    }
+
     iframe {
-        height: calc(100vh - 85px);
+        height: 100vh;
         width: 100%;
         border: none;
+    }
+
+    #q2templatesheader ~ .row > iframe {
+	height: calc(100vh - 85px);
     }
 </style>
 


### PR DESCRIPTION
Sibling selectors fix _everything_.