### PR TITLE
BLD: Update to beta-9

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - numpy
     - pandas
     - scikit-bio
-    - emperor 1.0.0beta8
+    - emperor 1.0.0beta9
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*


### PR DESCRIPTION
Can be installed with pip using:

```
pip install emperor --pre
```

However we are still waiting on conda-forge to finish the build:
https://travis-ci.org/conda-forge/emperor-feedstock/builds/269626755?utm_source=github_status&utm_medium=notification