### PR TITLE
BLD: Update emperor dependency version

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - numpy
     - pandas
     - scikit-bio
-    - emperor 1.0.0beta12
+    - emperor 1.0.0beta13
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*


### PR DESCRIPTION
Just waiting on Travis to start the macOS builds:
https://travis-ci.org/conda-forge/emperor-feedstock/builds/317162764?utm_source=github_status&utm_medium=notification

Linux builds seem to go fairly quickly:
https://circleci.com/gh/conda-forge/emperor-feedstock/30?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link