### PR TITLE
ENH: Add settings to the generic_plot function

### DIFF
--- a/q2_emperor/__init__.py
+++ b/q2_emperor/__init__.py
@@ -6,10 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from ._plot import plot, procrustes_plot, biplot
+from ._plot import plot, procrustes_plot, biplot, generic_plot
 from ._version import get_versions
 
 __version__ = get_versions()['version']
 del get_versions
 
-__all__ = ['plot', 'procrustes_plot', 'biplot']
+__all__ = ['plot', 'procrustes_plot', 'biplot', 'generic_plot']

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -17,10 +17,10 @@ from emperor import Emperor
 TEMPLATES = pkg_resources.resource_filename('q2_emperor', 'assets')
 
 
-def _generic_plot(output_dir: str, master: skbio.OrdinationResults,
-                  metadata: qiime2.Metadata,
-                  other_pcoa: skbio.OrdinationResults, plot_name,
-                  custom_axes: str=None):
+def generic_plot(output_dir: str, master: skbio.OrdinationResults,
+                 metadata: qiime2.Metadata,
+                 other_pcoa: skbio.OrdinationResults, plot_name,
+                 custom_axes: str=None, settings: dict=None):
 
     mf = metadata.to_dataframe()
 
@@ -37,6 +37,8 @@ def _generic_plot(output_dir: str, master: skbio.OrdinationResults,
     if other_pcoa:
         viz.procrustes_names = ['reference', 'other']
 
+    vis.settings = settings
+
     html = viz.make_emperor(standalone=True)
     viz.copy_support_files(output_dir)
     with open(os.path.join(output_dir, 'emperor.html'), 'w') as fh:
@@ -48,13 +50,13 @@ def _generic_plot(output_dir: str, master: skbio.OrdinationResults,
 
 def plot(output_dir: str, pcoa: skbio.OrdinationResults,
          metadata: qiime2.Metadata, custom_axes: str=None) -> None:
-    _generic_plot(output_dir, master=pcoa, metadata=metadata, other_pcoa=None,
-                  custom_axes=custom_axes, plot_name='plot')
+    generic_plot(output_dir, master=pcoa, metadata=metadata, other_pcoa=None,
+                 custom_axes=custom_axes, plot_name='plot')
 
 
 def procrustes_plot(output_dir: str, reference_pcoa: skbio.OrdinationResults,
                     other_pcoa: skbio.OrdinationResults,
                     metadata: qiime2.Metadata, custom_axes: str=None) -> None:
-    _generic_plot(output_dir, master=reference_pcoa, metadata=metadata,
-                  other_pcoa=other_pcoa, custom_axes=custom_axes,
-                  plot_name='procrustes_plot')
+    generic_plot(output_dir, master=reference_pcoa, metadata=metadata,
+                 other_pcoa=other_pcoa, custom_axes=custom_axes,
+                 plot_name='procrustes_plot')

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -22,7 +22,8 @@ TEMPLATES = pkg_resources.resource_filename('q2_emperor', 'assets')
 def generic_plot(output_dir: str, master: skbio.OrdinationResults,
                  metadata: qiime2.Metadata,
                  other_pcoa: skbio.OrdinationResults, plot_name,
-                 custom_axes: str=None, settings: dict=None):
+                 custom_axes: str = None, settings: dict = None,
+                 feature_metadata: qiime2.Metadata = None):
 
     mf = metadata.to_dataframe()
     if feature_metadata is not None:
@@ -42,7 +43,7 @@ def generic_plot(output_dir: str, master: skbio.OrdinationResults,
     if other_pcoa:
         viz.procrustes_names = ['reference', 'other']
 
-    vis.settings = settings
+    viz.settings = settings
 
     html = viz.make_emperor(standalone=True)
     viz.copy_support_files(output_dir)
@@ -54,14 +55,15 @@ def generic_plot(output_dir: str, master: skbio.OrdinationResults,
 
 
 def plot(output_dir: str, pcoa: skbio.OrdinationResults,
-         metadata: qiime2.Metadata, custom_axes: str=None) -> None:
+         metadata: qiime2.Metadata, custom_axes: str = None) -> None:
     generic_plot(output_dir, master=pcoa, metadata=metadata, other_pcoa=None,
                  custom_axes=custom_axes, plot_name='plot')
 
 
 def procrustes_plot(output_dir: str, reference_pcoa: skbio.OrdinationResults,
                     other_pcoa: skbio.OrdinationResults,
-                    metadata: qiime2.Metadata, custom_axes: str=None) -> None:
+                    metadata: qiime2.Metadata,
+                    custom_axes: str = None) -> None:
     generic_plot(output_dir, master=reference_pcoa, metadata=metadata,
                  other_pcoa=other_pcoa, custom_axes=custom_axes,
                  plot_name='procrustes_plot')
@@ -81,5 +83,5 @@ def biplot(output_dir: str, biplot: skbio.OrdinationResults,
     biplot.features = feats[:number_of_features].copy()
 
     generic_plot(output_dir, master=biplot, other_pcoa=None,
-                  metadata=sample_metadata, feature_metadata=feature_metadata,
-                  plot_name='biplot')
+                 metadata=sample_metadata, feature_metadata=feature_metadata,
+                 plot_name='biplot')

--- a/q2_emperor/tests/test_plot.py
+++ b/q2_emperor/tests/test_plot.py
@@ -90,3 +90,12 @@ class PlotTests(unittest.TestCase):
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())
+
+    def test_generic_plot_with_settings(self):
+        settings = {'color': 'val1'}
+        with tempfile.TemporaryDirectory() as output_dir:
+            generic_plot(output_dir, self.pcoa, self.metadata,
+                         settings=settings)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            self.assertTrue('src="./emperor.html"' in open(index_fp).read())

--- a/q2_emperor/tests/test_plot.py
+++ b/q2_emperor/tests/test_plot.py
@@ -15,7 +15,7 @@ import numpy as np
 import qiime2
 import skbio
 
-from q2_emperor import plot, procrustes_plot, biplot
+from q2_emperor import plot, procrustes_plot, biplot, generic_plot
 
 
 class PlotTests(unittest.TestCase):
@@ -103,10 +103,10 @@ class PlotTests(unittest.TestCase):
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())
 
     def test_generic_plot_with_settings(self):
-        settings = {'color': 'val1'}
+        settings = {'shape': {'category': 'val1', 'data': {}}}
         with tempfile.TemporaryDirectory() as output_dir:
-            generic_plot(output_dir, self.pcoa, self.metadata,
-                         settings=settings)
+            generic_plot(output_dir, self.pcoa, self.metadata, other_pcoa=None,
+                         plot_name='plot', settings=settings)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())


### PR DESCRIPTION
This adds an argument to an internal function of `q2-emperor`. The argument itself allows users to modify settings of the plot object. While this won't be available to users through QIIME2's Python API, this will still be available to users who import the Python package.

cc @AmandaBirmingham