### PR TITLE
ENH: Add a new visualizer for biplots

### DIFF
--- a/q2_emperor/__init__.py
+++ b/q2_emperor/__init__.py
@@ -6,10 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from ._plot import plot, procrustes_plot
+from ._plot import plot, procrustes_plot, biplot
 from ._version import get_versions
 
 __version__ = get_versions()['version']
 del get_versions
 
-__all__ = ['plot', 'procrustes_plot']
+__all__ = ['plot', 'procrustes_plot', 'biplot']

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -26,6 +26,8 @@ def _generic_plot(output_dir: str, master: skbio.OrdinationResults,
                   feature_metadata: qiime2.Metadata=None):
 
     mf = metadata.to_dataframe()
+    if feature_metadata is not None:
+        feature_metadata = feature_metadata.to_dataframe()
 
     if other_pcoa is None:
         procrustes = None

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -12,7 +12,9 @@ import pkg_resources
 import qiime2
 import skbio
 import q2templates
+import numpy as np
 from emperor import Emperor
+from scipy.spatial.distance import euclidean
 
 TEMPLATES = pkg_resources.resource_filename('q2_emperor', 'assets')
 
@@ -20,7 +22,8 @@ TEMPLATES = pkg_resources.resource_filename('q2_emperor', 'assets')
 def _generic_plot(output_dir: str, master: skbio.OrdinationResults,
                   metadata: qiime2.Metadata,
                   other_pcoa: skbio.OrdinationResults, plot_name,
-                  custom_axes: str=None):
+                  custom_axes: str=None,
+                  feature_metadata: qiime2.Metadata=None):
 
     mf = metadata.to_dataframe()
 
@@ -29,7 +32,8 @@ def _generic_plot(output_dir: str, master: skbio.OrdinationResults,
     else:
         procrustes = [other_pcoa]
 
-    viz = Emperor(master, mf, procrustes=procrustes, remote='.')
+    viz = Emperor(master, mf, feature_mapping_file=feature_metadata,
+                  procrustes=procrustes, remote='.')
 
     if custom_axes is not None:
         viz.custom_axes = custom_axes
@@ -58,3 +62,21 @@ def procrustes_plot(output_dir: str, reference_pcoa: skbio.OrdinationResults,
     _generic_plot(output_dir, master=reference_pcoa, metadata=metadata,
                   other_pcoa=other_pcoa, custom_axes=custom_axes,
                   plot_name='procrustes_plot')
+
+
+def biplot(output_dir: str, biplot: skbio.OrdinationResults,
+           sample_metadata: qiime2.Metadata, feature_metadata:
+           qiime2.Metadata=None,
+           number_of_features: int=5) -> None:
+
+    # select the top N most important features based on the vector's magnitude
+    feats = biplot.features.copy()
+    origin = np.zeros_like(feats.columns)
+    feats['importance'] = feats.apply(euclidean, axis=1, args=(origin,))
+    feats.sort_values('importance', inplace=True, ascending=False)
+    feats.drop(['importance'], inplace=True, axis=1)
+    biplot.features = feats[:number_of_features].copy()
+
+    _generic_plot(output_dir, master=biplot, other_pcoa=None,
+                  metadata=sample_metadata, feature_metadata=feature_metadata,
+                  plot_name='biplot')

--- a/q2_emperor/plugin_setup.py
+++ b/q2_emperor/plugin_setup.py
@@ -8,9 +8,9 @@
 
 
 import q2_emperor
-from ._plot import plot, procrustes_plot
+from ._plot import plot, procrustes_plot, biplot
 
-from qiime2.plugin import Plugin, Metadata, Str, List, Citations
+from qiime2.plugin import Plugin, Metadata, Str, List, Citations, Range, Int
 from q2_types.ordination import PCoAResults
 
 PARAMETERS = {'metadata': Metadata, 'custom_axes': List[Str]}
@@ -57,4 +57,25 @@ plugin.visualizers.register_function(
     parameter_descriptions=PARAMETERS_DESC,
     name='Visualize and Interact with a procrustes plot',
     description='Plot two procrustes-fitted matrices'
+)
+
+plugin.visualizers.register_function(
+    function=biplot,
+    inputs={'biplot': PCoAResults},
+    parameters={'sample_metadata': Metadata,
+                'feature_metadata': Metadata,
+                'number_of_features': Int % Range(1, None)},
+    input_descriptions={
+        'biplot': 'The principal coordinates matrix to be plotted.'
+    },
+    parameter_descriptions={
+        'sample_metadata': 'The sample metadata',
+        'feature_metadata': 'The feature metadata (useful to manipulate the '
+                            'arrows in the plot).',
+        'number_of_features': 'The number of most important features '
+                              '(arrows) to display in the ordination.',
+        },
+    name='Visualize and Interact with Principal Coordinates Analysis Biplot',
+    description='Generates an interactive ordination biplot where the user '
+                'can visually integrate sample and feature metadata.'
 )

--- a/q2_emperor/plugin_setup.py
+++ b/q2_emperor/plugin_setup.py
@@ -10,7 +10,8 @@
 import q2_emperor
 from ._plot import plot, procrustes_plot, biplot
 
-from qiime2.plugin import Plugin, Metadata, Str, List, Citations, Range, Int
+from qiime2.plugin import (Plugin, Metadata, Str, List, Citations, Range, Int,
+                           Properties)
 from q2_types.ordination import PCoAResults
 
 PARAMETERS = {'metadata': Metadata, 'custom_axes': List[Str]}
@@ -61,7 +62,7 @@ plugin.visualizers.register_function(
 
 plugin.visualizers.register_function(
     function=biplot,
-    inputs={'biplot': PCoAResults},
+    inputs={'biplot': PCoAResults % Properties("biplot")},
     parameters={'sample_metadata': Metadata,
                 'feature_metadata': Metadata,
                 'number_of_features': Int % Range(1, None)},

--- a/q2_emperor/tests/test_plot.py
+++ b/q2_emperor/tests/test_plot.py
@@ -111,11 +111,12 @@ class PlotTests(unittest.TestCase):
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())
 
     def test_biplot_with_feature_metadata(self):
-        feat_md = pd.DataFrame(index=['x', 'y', 'z'],
-                               columns=['k', 'p'],
-                               data=[['Bacteria', 'Firmicutes'],
-                                     ['Bacteria', 'Firmicutes'],
-                                     ['Bacteria', 'Bacteroidetes']])
+        feat_md = qiime2.Metadata(
+            pd.DataFrame(index=pd.Index(['x', 'y', 'z'], name='feature id'),
+                         columns=['k', 'p'],
+                         data=[['Bacteria', 'Firmicutes'],
+                               ['Bacteria', 'Firmicutes'],
+                               ['Bacteria', 'Bacteroidetes']]))
 
         with tempfile.TemporaryDirectory() as output_dir:
             biplot(output_dir, self.biplot,

--- a/q2_emperor/tests/test_plot.py
+++ b/q2_emperor/tests/test_plot.py
@@ -15,7 +15,7 @@ import numpy as np
 import qiime2
 import skbio
 
-from q2_emperor import plot, procrustes_plot
+from q2_emperor import plot, procrustes_plot, biplot
 
 
 class PlotTests(unittest.TestCase):
@@ -46,6 +46,17 @@ class PlotTests(unittest.TestCase):
                 'Principal Coordinate Analysis',
                 eigvals.copy(),
                 samples_df,
+                proportion_explained=proportion_explained.copy())
+
+        features = pd.DataFrame(index=['x', 'y', 'z'],
+                                columns=['PC1', 'PC2', 'PC3'],
+                                data=[[1, 2, 3], [1, 1, -1], [0, -2, 0.1]])
+        self.biplot = skbio.OrdinationResults(
+                'PCoA',
+                'Principal Coordinate Analysis',
+                eigvals.copy(),
+                samples_df,
+                features=features,
                 proportion_explained=proportion_explained.copy())
 
         self.metadata = qiime2.Metadata(
@@ -87,6 +98,28 @@ class PlotTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as output_dir:
             procrustes_plot(output_dir, self.pcoa, other_pcoa=self.other,
                             metadata=self.metadata, custom_axes=['val1'])
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            self.assertTrue('src="./emperor.html"' in open(index_fp).read())
+
+    def test_biplot(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            biplot(output_dir, self.biplot,
+                   sample_metadata=self.metadata)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            self.assertTrue('src="./emperor.html"' in open(index_fp).read())
+
+    def test_biplot_with_feature_metadata(self):
+        feat_md = pd.DataFrame(index=['x', 'y', 'z'],
+                               columns=['k', 'p'],
+                               data=[['Bacteria', 'Firmicutes'],
+                                     ['Bacteria', 'Firmicutes'],
+                                     ['Bacteria', 'Bacteroidetes']])
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            biplot(output_dir, self.biplot,
+                   sample_metadata=self.metadata, feature_metadata=feat_md)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())


### PR DESCRIPTION
Brief summary of the Pull Request, including any issues it may fix using the GitHub closing syntax:

This new visualizer displays a PCoA biplot in Emperor's interface.

#### Demo

In order to visualize a PCoA biplot, the user needs to project the feature data into the PCoA matrix. To do this, we use q2-diversity's pcoa-biplot method. However, before we need to normalize our data to represent relative abundances:

```bash
# rarefied-table.qza is as produced by the core-metrics command
qiime feature-table relative-frequency --i-table rarefied_table.qza \
--o-relative-frequency-table relative-abundance-rarefied-table.qza
```

Next we make the projection and select the number of features that we want to see in the PCoA plot:

```bash
qiime diversity pcoa-biplot --i-pcoa unweighted_unifrac_pcoa_results.qza \
--i-features relative-abundance-rarefied-table.qza \
--o-biplot unweighted-unifrac-relative-abundance-biplot.qza
```

And finally, we visualize this data with Emperor (selecting only the top 8 most important features):
```bash
qiime emperor biplot --i-biplot unweighted-unifrac-relative-abundance-biplot.qza \
--m-sample-metadata-file sample-metadata.tsv \
--o-visualization a-biplot.qzv \
--p-number-of-features 8
```

The result:

![biplot](https://user-images.githubusercontent.com/375307/44487923-545d0200-a60c-11e8-86f8-44851455d030.gif)


-----------------

Note that q2-emperor still needs to see an Emperor update that makes the UI nicer, etc (pushing that after this PR).