### PR TITLE
Bump the emperor version to a newer release

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - numpy
     - pandas
     - scikit-bio
-    - emperor 1.0.0beta16
+    - emperor 1.0.0beta17
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*


### PR DESCRIPTION
Depends on the conda-forge build to finish.

PR here:
https://github.com/conda-forge/emperor-feedstock/pull/18