### PR TITLE
ENH: Adding in invert option

### DIFF
--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -76,7 +76,7 @@ def procrustes_plot(output_dir: str, reference_pcoa: skbio.OrdinationResults,
 
 
 def biplot(output_dir: str, biplot: skbio.OrdinationResults,
-           point_metadata: qiime2.Metadata, arrow_metadata:
+           sample_metadata: qiime2.Metadata, feature_metadata:
            qiime2.Metadata = None,
            ignore_missing_samples: bool = False,
            invert: bool = False,
@@ -98,5 +98,5 @@ def biplot(output_dir: str, biplot: skbio.OrdinationResults,
 
     generic_plot(output_dir, master=biplot, other_pcoa=None,
                  ignore_missing_samples=ignore_missing_samples,
-                 metadata=point_metadata, feature_metadata=arrow_metadata,
+                 metadata=sample_metadata, feature_metadata=feature_metadata,
                  plot_name='biplot')

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -83,10 +83,7 @@ def biplot(output_dir: str, biplot: skbio.OrdinationResults,
            number_of_features: int = 5) -> None:
 
     if invert:
-        features = biplot.features.copy()
-        samples = biplot.samples.copy()
-        biplot.samples = features
-        biplot.features = samples
+        biplot.samples, biplot.features = biplot.features, biplot.samples
 
     # select the top N most important features based on the vector's magnitude
     feats = biplot.features.copy()

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -76,10 +76,17 @@ def procrustes_plot(output_dir: str, reference_pcoa: skbio.OrdinationResults,
 
 
 def biplot(output_dir: str, biplot: skbio.OrdinationResults,
-           sample_metadata: qiime2.Metadata, feature_metadata:
+           point_metadata: qiime2.Metadata, arrow_metadata:
            qiime2.Metadata = None,
            ignore_missing_samples: bool = False,
+           invert: bool = False,
            number_of_features: int = 5) -> None:
+
+    if invert:
+        features = biplot.features.copy()
+        samples = biplot.samples.copy()
+        biplot.samples = features
+        biplot.features = samples
 
     # select the top N most important features based on the vector's magnitude
     feats = biplot.features.copy()
@@ -91,5 +98,5 @@ def biplot(output_dir: str, biplot: skbio.OrdinationResults,
 
     generic_plot(output_dir, master=biplot, other_pcoa=None,
                  ignore_missing_samples=ignore_missing_samples,
-                 metadata=sample_metadata, feature_metadata=feature_metadata,
+                 metadata=point_metadata, feature_metadata=arrow_metadata,
                  plot_name='biplot')

--- a/q2_emperor/_plot.py
+++ b/q2_emperor/_plot.py
@@ -84,6 +84,7 @@ def biplot(output_dir: str, biplot: skbio.OrdinationResults,
 
     if invert:
         biplot.samples, biplot.features = biplot.features, biplot.samples
+        sample_metadata, feature_metadata = feature_metadata, sample_metadata
 
     # select the top N most important features based on the vector's magnitude
     feats = biplot.features.copy()

--- a/q2_emperor/plugin_setup.py
+++ b/q2_emperor/plugin_setup.py
@@ -87,7 +87,7 @@ plugin.visualizers.register_function(
     parameter_descriptions={
         'sample_metadata': 'The sample metadata',
         'feature_metadata': 'The feature metadata (useful to manipulate the '
-                          'arrows in the plot).',
+                            'arrows in the plot).',
         'invert': 'If specified, the point and arrow coordinates '
                   'will be swapped.',
         'ignore_missing_samples': PARAMETERS_DESC['ignore_missing_samples'],

--- a/q2_emperor/plugin_setup.py
+++ b/q2_emperor/plugin_setup.py
@@ -76,17 +76,20 @@ plugin.visualizers.register_function(
 plugin.visualizers.register_function(
     function=biplot,
     inputs={'biplot': PCoAResults % Properties("biplot")},
-    parameters={'sample_metadata': Metadata,
-                'feature_metadata': Metadata,
+    parameters={'point_metadata': Metadata,
+                'arrow_metadata': Metadata,
                 'ignore_missing_samples': Bool,
+                'invert': Bool,
                 'number_of_features': Int % Range(1, None)},
     input_descriptions={
         'biplot': 'The principal coordinates matrix to be plotted.'
     },
     parameter_descriptions={
-        'sample_metadata': 'The sample metadata',
-        'feature_metadata': 'The feature metadata (useful to manipulate the '
-                            'arrows in the plot).',
+        'point_metadata': 'The sample metadata',
+        'arrow_metadata': 'The feature metadata (useful to manipulate the '
+                          'arrows in the plot).',
+        'invert': 'If specified, the point and arrow coordinates '
+                  'will be swapped.',
         'ignore_missing_samples': PARAMETERS_DESC['ignore_missing_samples'],
         'number_of_features': 'The number of most important features '
                               '(arrows) to display in the ordination.'

--- a/q2_emperor/plugin_setup.py
+++ b/q2_emperor/plugin_setup.py
@@ -76,8 +76,8 @@ plugin.visualizers.register_function(
 plugin.visualizers.register_function(
     function=biplot,
     inputs={'biplot': PCoAResults % Properties("biplot")},
-    parameters={'point_metadata': Metadata,
-                'arrow_metadata': Metadata,
+    parameters={'sample_metadata': Metadata,
+                'feature_metadata': Metadata,
                 'ignore_missing_samples': Bool,
                 'invert': Bool,
                 'number_of_features': Int % Range(1, None)},
@@ -85,8 +85,8 @@ plugin.visualizers.register_function(
         'biplot': 'The principal coordinates matrix to be plotted.'
     },
     parameter_descriptions={
-        'point_metadata': 'The sample metadata',
-        'arrow_metadata': 'The feature metadata (useful to manipulate the '
+        'sample_metadata': 'The sample metadata',
+        'feature_metadata': 'The feature metadata (useful to manipulate the '
                           'arrows in the plot).',
         'invert': 'If specified, the point and arrow coordinates '
                   'will be swapped.',

--- a/q2_emperor/tests/test_plot.py
+++ b/q2_emperor/tests/test_plot.py
@@ -114,12 +114,12 @@ class PlotTests(unittest.TestCase):
     def test_biplot(self):
         with tempfile.TemporaryDirectory() as output_dir:
             biplot(output_dir, self.biplot,
-                   sample_metadata=self.metadata)
+                   point_metadata=self.metadata)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())
 
-    def test_biplot_with_feature_metadata(self):
+    def test_biplot_with_arrow_metadata(self):
         feat_md = qiime2.Metadata(
             pd.DataFrame(index=pd.Index(['x', 'y', 'z'], name='feature id'),
                          columns=['k', 'p'],
@@ -129,7 +129,23 @@ class PlotTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as output_dir:
             biplot(output_dir, self.biplot,
-                   sample_metadata=self.metadata, feature_metadata=feat_md)
+                   point_metadata=self.metadata, arrow_metadata=feat_md)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            self.assertTrue('src="./emperor.html"' in open(index_fp).read())
+
+    def test_biplot_invert(self):
+        feat_md = qiime2.Metadata(
+            pd.DataFrame(index=pd.Index(['x', 'y', 'z'], name='feature id'),
+                         columns=['k', 'p'],
+                         data=[['Bacteria', 'Firmicutes'],
+                               ['Bacteria', 'Firmicutes'],
+                               ['Bacteria', 'Bacteroidetes']]))
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            biplot(output_dir, self.biplot,
+                   point_metadata=feat_md, arrow_metadata=self.metadata,
+                   invert=True)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())

--- a/q2_emperor/tests/test_plot.py
+++ b/q2_emperor/tests/test_plot.py
@@ -114,12 +114,12 @@ class PlotTests(unittest.TestCase):
     def test_biplot(self):
         with tempfile.TemporaryDirectory() as output_dir:
             biplot(output_dir, self.biplot,
-                   point_metadata=self.metadata)
+                   sample_metadata=self.metadata)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())
 
-    def test_biplot_with_arrow_metadata(self):
+    def test_biplot_with_feature_metadata(self):
         feat_md = qiime2.Metadata(
             pd.DataFrame(index=pd.Index(['x', 'y', 'z'], name='feature id'),
                          columns=['k', 'p'],
@@ -129,7 +129,7 @@ class PlotTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as output_dir:
             biplot(output_dir, self.biplot,
-                   point_metadata=self.metadata, arrow_metadata=feat_md)
+                   sample_metadata=self.metadata, feature_metadata=feat_md)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
             self.assertTrue('src="./emperor.html"' in open(index_fp).read())
@@ -144,7 +144,7 @@ class PlotTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as output_dir:
             biplot(output_dir, self.biplot,
-                   point_metadata=feat_md, arrow_metadata=self.metadata,
+                   sample_metadata=feat_md, feature_metadata=self.metadata,
                    invert=True)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))

--- a/q2_emperor/tests/test_plot.py
+++ b/q2_emperor/tests/test_plot.py
@@ -144,7 +144,7 @@ class PlotTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as output_dir:
             biplot(output_dir, self.biplot,
-                   sample_metadata=feat_md, feature_metadata=self.metadata,
+                   sample_metadata=self.metadata, feature_metadata=feat_md,
                    invert=True)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))


### PR DESCRIPTION
This PR accomplishes 2 things

1. Renames samples/features -> points/arrows
2. Adds an inversion flag to allow for points to be swapped with arrows.

This resolves the following issues

https://github.com/qiime2/q2-diversity/issues/258
https://github.com/biocore/emperor/issues/732
https://github.com/qiime2/q2-emperor/issues/82

See the following screenshot

![image](https://user-images.githubusercontent.com/4184797/63620649-e8ff9480-c5bf-11e9-95db-8a910ed1e7dd.png)


CC @ElDeveloper @thermokarst @nbokulich 