### PR TITLE
REL: Bump release version of emperor

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy
     - pandas
     - scikit-bio
-    - emperor 1.0.0b19
+    - emperor 1.0.0b20
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*


### PR DESCRIPTION
Currently depends on the build completing over at: https://github.com/conda-forge/emperor-feedstock/pull/23