### PR TITLE
BLD: Update to beta21 of emperor

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy
     - pandas
     - scikit-bio
-    - emperor 1.0.0b20
+    - emperor 1.0.0b21
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy
     - pandas
     - scikit-bio
-    - emperor 1.0.0b21
+    - emperor 1.0.0
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*


### PR DESCRIPTION
Depends on https://github.com/biocore/emperor/pull/746 and https://github.com/biocore/emperor/pull/750 getting merged, as well as pushing out a new release.