### PR TITLE
REL: Bump to newest release 1.0.1

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy
     - pandas
     - scikit-bio
-    - emperor 1.0.0
+    - emperor 1.0.1
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*


### PR DESCRIPTION
Bumps dependency version to 1.0.1, depends on the following PR being merged and creating a new release:

https://github.com/biocore/emperor/pull/773