### PR TITLE
ex: adds emperor usage-examples

### DIFF
--- a/q2_emperor/_examples.py
+++ b/q2_emperor/_examples.py
@@ -1,0 +1,34 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2022, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from qiime2 import Visualization
+
+
+pcoa_results_url = 'https://docs.qiime2.org/2022.8/data/tutorials/' \
+    'moving-pictures/core-metrics-results/bray_curtis_pcoa_results.qza'
+
+metadata_url = 'https://data.qiime2.org/{epoch}/tutorials/' \
+               'moving-pictures/sample_metadata.tsv'
+
+def plot(use):
+    pcoa_results = use.init_artifact_from_url('pcoa_result', pcoa_results_url)
+    metadata = use.init_metadata_from_url('sample_metadata', metadata_url)
+
+    viz, = use.action(
+        use.UsageAction('emperor', 'plot'),
+        use.UsageInputs(
+            pcoa=pcoa_results,
+            metadata=metadata
+            ),
+        use.UsageOutputNames(
+            visualization='plot'
+        )
+    )
+
+    viz.assert_output_type('Visualization')
+

--- a/q2_emperor/plugin_setup.py
+++ b/q2_emperor/plugin_setup.py
@@ -13,6 +13,7 @@ from ._plot import plot, procrustes_plot, biplot
 from qiime2.plugin import (Plugin, Metadata, Str, List, Citations, Range, Int,
                            Bool, Properties)
 from q2_types.ordination import PCoAResults, ProcrustesStatistics
+import q2_emperor._examples as ex
 
 PARAMETERS = {'metadata': Metadata, 'custom_axes': List[Str],
               'ignore_missing_samples': Bool}
@@ -67,7 +68,8 @@ plugin.visualizers.register_function(
     parameter_descriptions=PLOT_PARAMETERS_DESC,
     name='Visualize and Interact with Principal Coordinates Analysis Plots',
     description='Generates an interactive ordination plot where the user '
-                'can visually integrate sample metadata.'
+                'can visually integrate sample metadata.',
+    examples={'emperor_plot': ex.plot }
 )
 
 plugin.visualizers.register_function(

--- a/q2_emperor/tests/test_plot.py
+++ b/q2_emperor/tests/test_plot.py
@@ -17,6 +17,13 @@ import skbio
 
 from q2_emperor import plot, procrustes_plot, biplot, generic_plot
 
+from qiime2.plugin.testing import TestPluginBase
+
+class TestBase(TestPluginBase):
+    package = 'q2_emperor.tests'
+
+    def test_examples(self):
+        self.execute_examples()
 
 class PlotTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR is part of our 2022 Hacktoberfest team-wide sprint to add usage examples to all methods in each of our core distribution plugins. The methods examples have been added for are as follows:

`emperor plot `

- [ ] Bioplot 
- [ ] procrustes-plot