### PR TITLE
bug: fix dynamic URL causing usage example failure

### DIFF
--- a/q2_emperor/_examples.py
+++ b/q2_emperor/_examples.py
@@ -14,8 +14,8 @@ unweighted_pcoa_results_url = ('https://data.qiime2.org/usage-examples/'
                                'moving-pictures/core-metrics-results/'
                                'unweighted_unifrac_pcoa_results.qza')
 
-metadata_url = (f'https://data.qiime2.org/{qiime2.__release__}/tutorials/'
-                'moving-pictures/sample_metadata.tsv')
+metadata_url = ('https://data.qiime2.org/usage-examples/'
+                'moving-pictures/sample-metadata.tsv')
 
 
 def plot(use):

--- a/q2_emperor/_examples.py
+++ b/q2_emperor/_examples.py
@@ -5,7 +5,6 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-import qiime2
 
 bc_pcoa_results_url = ('https://data.qiime2.org/usage-examples/'
                        'moving-pictures/core-metrics-results/'


### PR DESCRIPTION
updating usage example URL that is dynamically generated to a static usage-specific URL so that it doesn't fail with each new dev bump